### PR TITLE
Wayland default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,9 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # title
-ENV TITLE=Altus 
+ENV TITLE=Altus \
+    NO_GAMEPAD=true \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -43,7 +43,9 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="thelamer"
 
 # title
-ENV TITLE=Altus
+ENV TITLE=Altus \
+    NO_GAMEPAD=true \
+    PIXELFLUX_WAYLAND=true
 
 COPY --from=build-stage /opt/altus /opt/altus
 

--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **03.04.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **21.03.26:** - Use Wayland ozone platform fixes scaling and acceleration.
 * **28.12.25:** - Add Wayland init logic.
 * **22.09.25:** - Rebase to Debian Trixie.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -107,6 +107,7 @@ init_diagram: |
   "altus:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "03.04.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "21.03.26:", desc: "Use Wayland ozone platform fixes scaling and acceleration."}
   - {date: "28.12.25:", desc: "Add Wayland init logic."}
   - {date: "22.09.25:", desc: "Rebase to Debian Trixie."}

--- a/root/defaults/autostart_wayland
+++ b/root/defaults/autostart_wayland
@@ -1,1 +1,1 @@
-/opt/altus/Altus --ozone-platform=wayland --no-sandbox
+altus

--- a/root/defaults/menu_wayland.xml
+++ b/root/defaults/menu_wayland.xml
@@ -2,6 +2,6 @@
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
 <item label="foot" icon="/usr/share/icons/hicolor/48x48/apps/foot.png"><action name="Execute"><command>/usr/bin/foot</command></action></item>
-<item label="Altus" icon="/opt/altus/Altus.png"><action name="Execute"><command>/opt/altus/Altus --ozone-platform=wayland --no-sandbox</command></action></item>
+<item label="Altus" icon="/opt/altus/Altus.png"><action name="Execute"><command>altus</command></action></item>
 </menu>
 </openbox_menu>

--- a/root/usr/bin/altus
+++ b/root/usr/bin/altus
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+BIN=/opt/altus/Altus
+
+# Wayland check
+if ls -l /dev/dri/* > /dev/null 2>&1; then
+  if pgrep labwc > /dev/null 2>&1; then
+    WAYLAND="--ozone-platform=wayland"
+  fi
+fi
+
+${BIN} --password-store=basic ${WAYLAND} --no-sandbox "$@"


### PR DESCRIPTION
Basic wayland cutover, adds a binwrapper because ozone wayland will not run without a GPU until they update their CEF. 